### PR TITLE
Tests: Define and use with-fixture macro

### DIFF
--- a/test/elfeed-protocol-newsblur-test.el
+++ b/test/elfeed-protocol-newsblur-test.el
@@ -11,65 +11,60 @@
   (concat elfeed-protocol-newsblur-fixture-dir "entries.json"))
 
 (ert-deftest elfeed-protocol-newsblur-parse-feeds ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-newsblur-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-newsblur-fixture-feeds
     (with-elfeed-test
-     (let* ((proto-url "newsblur+https://user:pass@newsblur.com")
-            (host-url (elfeed-protocol-url proto-url))
-            (proto-id (elfeed-protocol-newsblur-id host-url))
-            (elfeed-feeds (list proto-url))
-            (elfeed-protocol-newsblur-feeds (elfeed-protocol-newsblur--parse-result
-                                             (elfeed-protocol-newsblur--parse-feeds
-                                              host-url result)))
-            (test-orig-feed-url (elfeed-protocol-newsblur--get-subfeed-url host-url 569))
-            (test-feed (elfeed-db-get-feed
-                        (elfeed-protocol-format-subfeed-id proto-id test-orig-feed-url))))
-       (should (string=
-                test-orig-feed-url
-                "http://anildash.com/"))
-       (should (string=
-                (elfeed-feed-url test-feed)
-                (elfeed-protocol-format-subfeed-id proto-id "http://anildash.com/")))
-       (should (string=
-                (elfeed-feed-title test-feed)
-                "Anil Dash"))
-       ))))
+      (let* ((proto-url "newsblur+https://user:pass@newsblur.com")
+             (host-url (elfeed-protocol-url proto-url))
+             (proto-id (elfeed-protocol-newsblur-id host-url))
+             (elfeed-feeds (list proto-url))
+             (elfeed-protocol-newsblur-feeds (elfeed-protocol-newsblur--parse-result
+                                               (elfeed-protocol-newsblur--parse-feeds
+                                                host-url result)))
+             (test-orig-feed-url (elfeed-protocol-newsblur--get-subfeed-url host-url 569))
+             (test-feed (elfeed-db-get-feed
+                         (elfeed-protocol-format-subfeed-id proto-id test-orig-feed-url))))
+        (should (string=
+                 test-orig-feed-url
+                 "http://anildash.com/"))
+        (should (string=
+                 (elfeed-feed-url test-feed)
+                 (elfeed-protocol-format-subfeed-id proto-id "http://anildash.com/")))
+        (should (string=
+                 (elfeed-feed-title test-feed)
+                 "Anil Dash"))
+        ))))
 
 (ert-deftest elfeed-protocol-newsblur-parse-entries ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-newsblur-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-newsblur-fixture-feeds
     (with-elfeed-test
-     (let* ((proto-url "newsblur+https://user:pass@myhost.com")
-            (host-url (elfeed-protocol-url proto-url))
-            (proto-id (elfeed-protocol-newsblur-id host-url))
-            (elfeed-feeds (list (list proto-url
-                                      :autotags
-                                      '(("http://anildash.com/" tag1)))))
-            (elfeed-protocol-newsblur-feeds (elfeed-protocol-newsblur--parse-result
-                                           (elfeed-protocol-newsblur--parse-feeds
-                                            host-url result))))
-       (with-temp-buffer
-         (insert-file-contents elfeed-protocol-newsblur-fixture-entries)
-         (goto-char (point-min))
-         (let* ((entries (elfeed-protocol-newsblur--parse-result
-                           (elfeed-protocol-newsblur--parse-entries
-                            host-url result)))
-                (entry1 (elt entries 0))
-                (entry2 (elt entries 1)))
-           (should (elfeed-protocol-newsblur-entry-p entry1))
-           (should (elfeed-protocol-newsblur-entry-p entry2))
-           (should (string=
-                    (elfeed-entry-title entry1)
-                    "Ask HN: What software/service helps you be an effective remote developer?"))
-           (should (string=
-                    (elfeed-entry-title entry2)
-                    "Jessica Jones’ second season gets its first teaser"))
-           (should (equal
-                    (elfeed-entry-tags entry1)
-                    '(tag1)))
-           (should (equal
-                    (elfeed-entry-tags entry2)
-                    `(hyperloop ,(intern "fundings & exits") star unread)))
-           ))))))
+      (let* ((proto-url "newsblur+https://user:pass@myhost.com")
+             (host-url (elfeed-protocol-url proto-url))
+             (proto-id (elfeed-protocol-newsblur-id host-url))
+             (elfeed-feeds (list (list proto-url
+                                       :autotags
+                                       '(("http://anildash.com/" tag1)))))
+             (elfeed-protocol-newsblur-feeds (elfeed-protocol-newsblur--parse-result
+                                               (elfeed-protocol-newsblur--parse-feeds
+                                                host-url result))))
+        (with-fixture elfeed-protocol-newsblur-fixture-entries
+          (let* ((entries (elfeed-protocol-newsblur--parse-result
+                            (elfeed-protocol-newsblur--parse-entries
+                             host-url result)))
+                 (entry1 (elt entries 0))
+                 (entry2 (elt entries 1)))
+            (should (elfeed-protocol-newsblur-entry-p entry1))
+            (should (elfeed-protocol-newsblur-entry-p entry2))
+            (should (string=
+                     (elfeed-entry-title entry1)
+                     "Ask HN: What software/service helps you be an effective remote developer?"))
+            (should (string=
+                     (elfeed-entry-title entry2)
+                     "Jessica Jones’ second season gets its first teaser"))
+            (should (equal
+                     (elfeed-entry-tags entry1)
+                     '(tag1)))
+            (should (equal
+                     (elfeed-entry-tags entry2)
+                     `(hyperloop ,(intern "fundings & exits") star unread)))
+            )
+          )))))

--- a/test/elfeed-protocol-owncloud-test.el
+++ b/test/elfeed-protocol-owncloud-test.el
@@ -11,74 +11,68 @@
   (concat elfeed-protocol-owncloud-fixtures-dir "entries.json"))
 
 (ert-deftest elfeed-protocol-owncloud-parse-feeds ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-owncloud-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-owncloud-fixture-feeds
     (with-elfeed-test
-     (let* ((url "https://user:pass@myhost.com:443")
-            (proto-url (concat "owncloud+" url))
-            (proto-id (elfeed-protocol-owncloud-id url))
-            (elfeed-feeds (list proto-url))
-            (elfeed-protocol-owncloud-feeds (elfeed-protocol-owncloud--parse-feeds url))
-            (feed1-url (elfeed-protocol-owncloud--get-subfeed-url url 1))
-            (feed1 (elfeed-db-get-feed
-                    (elfeed-protocol-format-subfeed-id proto-id feed1-url)))
-            (feed2-url (elfeed-protocol-owncloud--get-subfeed-url url 2))
-            (feed2 (elfeed-db-get-feed
-                    (elfeed-protocol-format-subfeed-id proto-id feed2-url)))
-            )
-       (should (string=
-                feed1-url
-                "http://www.example.com/feed/"))
-       (should (string=
-                feed2-url
-                "http://www.example2.com/rss.jsp"))
-       (should (string=
-                (elfeed-feed-url feed1)
-                (elfeed-protocol-format-subfeed-id proto-id "http://www.example.com/feed/")))
-       (should (string=
-                (elfeed-feed-url feed2)
-                (elfeed-protocol-format-subfeed-id proto-id "http://www.example2.com/rss.jsp")))
-       (should (string=
-                (elfeed-feed-title feed1)
-                "Feed 1"))
-       (should (string=
-                (elfeed-feed-title feed2)
-                "Feed 2"))
-       ))))
+      (let* ((url "https://user:pass@myhost.com:443")
+             (proto-url (concat "owncloud+" url))
+             (proto-id (elfeed-protocol-owncloud-id url))
+             (elfeed-feeds (list proto-url))
+             (elfeed-protocol-owncloud-feeds (elfeed-protocol-owncloud--parse-feeds url))
+             (feed1-url (elfeed-protocol-owncloud--get-subfeed-url url 1))
+             (feed1 (elfeed-db-get-feed
+                     (elfeed-protocol-format-subfeed-id proto-id feed1-url)))
+             (feed2-url (elfeed-protocol-owncloud--get-subfeed-url url 2))
+             (feed2 (elfeed-db-get-feed
+                     (elfeed-protocol-format-subfeed-id proto-id feed2-url)))
+             )
+        (should (string=
+                 feed1-url
+                 "http://www.example.com/feed/"))
+        (should (string=
+                 feed2-url
+                 "http://www.example2.com/rss.jsp"))
+        (should (string=
+                 (elfeed-feed-url feed1)
+                 (elfeed-protocol-format-subfeed-id proto-id "http://www.example.com/feed/")))
+        (should (string=
+                 (elfeed-feed-url feed2)
+                 (elfeed-protocol-format-subfeed-id proto-id "http://www.example2.com/rss.jsp")))
+        (should (string=
+                 (elfeed-feed-title feed1)
+                 "Feed 1"))
+        (should (string=
+                 (elfeed-feed-title feed2)
+                 "Feed 2"))
+        ))
+    ))
 
 (ert-deftest elfeed-protocol-owncloud-parse-entries ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-owncloud-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-owncloud-fixture-feeds
     (with-elfeed-test
-     (let* ((url "https://user:pass@myhost.com:443")
-            (proto-url (concat "owncloud+" url))
-            (proto-id (elfeed-protocol-owncloud-id url))
-            (elfeed-feeds (list (list proto-url :autotags
-                                      '(("http://www.example.com/feed/" tag1)
-                                        ("http://www.example2.com/rss.jsp" tag2)))))
-            (elfeed-protocol-owncloud-feeds (elfeed-protocol-owncloud--parse-feeds url)))
-       (with-temp-buffer
-         (insert-file-contents elfeed-protocol-owncloud-fixture-entries)
-         (goto-char (point-min))
-         (let* (
-                (entries (elfeed-protocol-owncloud--parse-entries url))
-                (entry1 (elt entries 0))
-                (entry2 (elt entries 1))
-                )
-           (should (elfeed-protocol-owncloud-entry-p entry1))
-           (should (elfeed-protocol-owncloud-entry-p entry2))
-           (should (string=
-                    (elfeed-entry-title entry1)
-                    "Entry 1"))
-           (should (string=
-                    (elfeed-entry-title entry2)
-                   "Entry 2"))
-           (should (equal
-                    (elfeed-entry-tags entry1)
-                    '(tag1)))
-           (should (equal
-                    (elfeed-entry-tags entry2)
-                    '(star tag2 unread)))
-           ))))))
+      (let* ((url "https://user:pass@myhost.com:443")
+             (proto-url (concat "owncloud+" url))
+             (proto-id (elfeed-protocol-owncloud-id url))
+             (elfeed-feeds (list (list proto-url :autotags
+                                       '(("http://www.example.com/feed/" tag1)
+                                         ("http://www.example2.com/rss.jsp" tag2)))))
+             (elfeed-protocol-owncloud-feeds (elfeed-protocol-owncloud--parse-feeds url)))
+        (with-fixture elfeed-protocol-owncloud-fixture-entries
+          (let* ((entries (elfeed-protocol-owncloud--parse-entries url))
+                 (entry1 (elt entries 0))
+                 (entry2 (elt entries 1)))
+            (should (elfeed-protocol-owncloud-entry-p entry1))
+            (should (elfeed-protocol-owncloud-entry-p entry2))
+            (should (string=
+                     (elfeed-entry-title entry1)
+                     "Entry 1"))
+            (should (string=
+                     (elfeed-entry-title entry2)
+                     "Entry 2"))
+            (should (equal
+                     (elfeed-entry-tags entry1)
+                     '(tag1)))
+            (should (equal
+                     (elfeed-entry-tags entry2)
+                     '(star tag2 unread)))
+            )
+          )))))

--- a/test/elfeed-protocol-ttrss-test.el
+++ b/test/elfeed-protocol-ttrss-test.el
@@ -14,96 +14,91 @@
   (concat elfeed-protocol-ttrss-fixture-dir "entries-no-feed-id.json"))
 
 (ert-deftest elfeed-protocol-ttrss-parse-feeds ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-ttrss-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-ttrss-fixture-feeds
     (with-elfeed-test
-     (let* ((proto-url "ttrss+https://user:pass@myhost.com:443")
-            (host-url (elfeed-protocol-url proto-url))
-            (proto-id (elfeed-protocol-ttrss-id host-url))
-            (elfeed-feeds (list proto-url))
-            (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
-                                           (elfeed-protocol-ttrss--parse-feeds
-                                            host-url content)))
-            (test-feed-url (elfeed-protocol-ttrss--get-subfeed-url host-url 1))
-            (test-feed (elfeed-db-get-feed
-                        (elfeed-protocol-format-subfeed-id proto-id test-feed-url))))
-       (should (string=
-                test-feed-url
-                "http://tt-rss.org/forum/rss.php"))
-       (should (string=
-                (elfeed-feed-url test-feed)
-                (elfeed-protocol-format-subfeed-id proto-id "http://tt-rss.org/forum/rss.php")))
-       (should (string=
-                (elfeed-feed-title test-feed)
-                "Tiny Tiny RSS: Forum"))
-       ))))
+      (let* ((proto-url "ttrss+https://user:pass@myhost.com:443")
+             (host-url (elfeed-protocol-url proto-url))
+             (proto-id (elfeed-protocol-ttrss-id host-url))
+             (elfeed-feeds (list proto-url))
+             (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
+                                            (elfeed-protocol-ttrss--parse-feeds
+                                             host-url content)))
+             (test-feed-url (elfeed-protocol-ttrss--get-subfeed-url host-url 1))
+             (test-feed (elfeed-db-get-feed
+                         (elfeed-protocol-format-subfeed-id proto-id test-feed-url))))
+        (should (string=
+                 test-feed-url
+                 "http://tt-rss.org/forum/rss.php"))
+        (should (string=
+                 (elfeed-feed-url test-feed)
+                 (elfeed-protocol-format-subfeed-id proto-id "http://tt-rss.org/forum/rss.php")))
+        (should (string=
+                 (elfeed-feed-title test-feed)
+                 "Tiny Tiny RSS: Forum"))
+        ))))
 
 (ert-deftest elfeed-protocol-ttrss-parse-entries ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-ttrss-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-ttrss-fixture-feeds
     (with-elfeed-test
-     (let* ((proto-url "ttrss+https://user:pass@myhost.com")
-            (host-url (elfeed-protocol-url proto-url))
-            (proto-id (elfeed-protocol-ttrss-id host-url))
-            (elfeed-feeds (list (list proto-url
-                                      :autotags
-                                      '(("http://tt-rss.org/forum/rss.php" tag1)))))
-            (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
-                                           (elfeed-protocol-ttrss--parse-feeds
-                                            host-url content))))
-       (with-temp-buffer
-         (insert-file-contents elfeed-protocol-ttrss-fixture-entries)
-         (goto-char (point-min))
-         (let* ((entries (elfeed-protocol-ttrss--parse-result
-                           (elfeed-protocol-ttrss--parse-entries
-                            host-url content)))
-                (entry1 (elt entries 0))
-                (entry2 (elt entries 1)))
-           (should (elfeed-protocol-ttrss-entry-p entry1))
-           (should (elfeed-protocol-ttrss-entry-p entry2))
-           (should (string=
-                    (elfeed-entry-title entry1)
-                    "Pictures not shown in some feeds with figure block"))
-           (should (string=
-                    (elfeed-entry-title entry2)
-                    "PDO is coming, here's what you need to know"))
-           (should (equal
-                    (elfeed-entry-tags entry1)
-                    '(tag1)))
-           (should (equal
-                    (elfeed-entry-tags entry2)
-                    '(ttrss_tag2 ttrss_tag1 publish star tag1 unread)))
-           ))))))
+      (let* ((proto-url "ttrss+https://user:pass@myhost.com")
+             (host-url (elfeed-protocol-url proto-url))
+             (proto-id (elfeed-protocol-ttrss-id host-url))
+             (elfeed-feeds (list (list proto-url
+                                       :autotags
+                                       '(("http://tt-rss.org/forum/rss.php" tag1)))))
+             (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
+                                            (elfeed-protocol-ttrss--parse-feeds
+                                             host-url content))))
+        (with-fixture elfeed-protocol-ttrss-fixture-entries
+          (let* ((entries (elfeed-protocol-ttrss--parse-result
+                            (elfeed-protocol-ttrss--parse-entries
+                             host-url content)))
+                 (entry1 (elt entries 0))
+                 (entry2 (elt entries 1)))
+            (should (elfeed-protocol-ttrss-entry-p entry1))
+            (should (elfeed-protocol-ttrss-entry-p entry2))
+            (should (string=
+                     (elfeed-entry-title entry1)
+                     "Pictures not shown in some feeds with figure block"))
+            (should (string=
+                     (elfeed-entry-title entry2)
+                     "PDO is coming, here's what you need to know"))
+            (should (equal
+                     (elfeed-entry-tags entry1)
+                     '(tag1)))
+            (should (equal
+                     (elfeed-entry-tags entry2)
+                     '(ttrss_tag2 ttrss_tag1 publish star tag1 unread)))
+            )
+          )
+        ))))
 
 (ert-deftest elfeed-protocol-ttrss-parse-no-feed-id-entries ()
-  (with-temp-buffer
-    (insert-file-contents elfeed-protocol-ttrss-fixture-feeds)
-    (goto-char (point-min))
+  (with-fixture elfeed-protocol-ttrss-fixture-feeds
     (with-elfeed-test
-     (let* ((proto-url "ttrss+https://user:pass@myhost.com")
-            (host-url (elfeed-protocol-url proto-url))
-            (proto-id (elfeed-protocol-ttrss-id host-url))
-            (elfeed-feeds (list (list proto-url
-                                      :autotags
-                                      '(("http://tt-rss.org/forum/rss.php" tag1)))))
-            (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
-                                           (elfeed-protocol-ttrss--parse-feeds
-                                            host-url content))))
-       (with-temp-buffer
-         (insert-file-contents elfeed-protocol-ttrss-fixture-no-feed-id-entries)
-         (goto-char (point-min))
-         (let* ((entries (elfeed-protocol-ttrss--parse-result
-                           (elfeed-protocol-ttrss--parse-entries
-                            host-url content)))
-                (entry1 (elt entries 0)))
-           (should (equal (length entries) 1))
-           (should (elfeed-protocol-ttrss-entry-p entry1))
-           (should (string=
-                    (elfeed-entry-title entry1)
-                    "Pictures not shown in some feeds with figure block"))
-           (should (equal
-                    (elfeed-entry-tags entry1)
-                    '(star tag1 unread)))
-           ))))))
+      (let* ((proto-url "ttrss+https://user:pass@myhost.com")
+             (host-url (elfeed-protocol-url proto-url))
+             (proto-id (elfeed-protocol-ttrss-id host-url))
+             (elfeed-feeds (list (list proto-url
+                                       :autotags
+                                       '(("http://tt-rss.org/forum/rss.php" tag1)))))
+             (elfeed-protocol-ttrss-feeds (elfeed-protocol-ttrss--parse-result
+                                            (elfeed-protocol-ttrss--parse-feeds
+                                             host-url content))))
+
+        (with-fixture elfeed-protocol-ttrss-fixture-no-feed-id-entries
+
+          (let* ((entries (elfeed-protocol-ttrss--parse-result
+                            (elfeed-protocol-ttrss--parse-entries
+                             host-url content)))
+                 (entry1 (elt entries 0)))
+            (should (equal (length entries) 1))
+            (should (elfeed-protocol-ttrss-entry-p entry1))
+            (should (string=
+                     (elfeed-entry-title entry1)
+                     "Pictures not shown in some feeds with figure block"))
+            (should (equal
+                     (elfeed-entry-tags entry1)
+                     '(star tag1 unread)))
+            )
+          )))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -22,3 +22,12 @@
      (unwind-protect
          (progn ,@body)
        (delete-directory temp-dir :recursive))))
+
+(defmacro with-fixture (fixture-path &rest body)
+  "Run BODY with the contents of the file specified by
+FIXTURE-PATH inserted into a temporary buffer."
+  (declare (indent defun))
+  `(with-temp-buffer
+     (insert-file-contents ,fixture-path)
+     (goto-char (point-min))
+     ,@body))


### PR DESCRIPTION
This commit removes some boilerplate-related tedium from the unit-testing experience, outsourcing repeated fixture-loading logic to a new macro.