### PR TITLE
Add `:password-eval` auth mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Setup elfeed-protocol, then switch to search view and and press G to update entr
 
                     ;; format 5, for password in gnome-keyring
                     (list "owncloud+https://user5@myhost.com"
-                          :password (shell-command-to-string "secret-tool lookup attribute value"))
+                          :password-eval (shell-command-to-string "secret-tool lookup attribute value"))
+
+                    ;; format 5, for password in pass(1), using password-store.el
+                    (list "owncloud+https://user5@myhost.com"
+                          :password-eval (password-store-get "owncloud/app-pass"))
 
                     ;; use autotags
                     (list "owncloud+https://user6@myhost.com"

--- a/README.md
+++ b/README.md
@@ -25,34 +25,34 @@ Setup elfeed-protocol, then switch to search view and and press G to update entr
 (setq elfeed-curl-extra-arguments '("--insecure")) ;necessary for https without a trust certificate
 ;; setup extra protocol feeds
 (require 'elfeed-protocol)
-(setq elfeed-feeds (list
-                    ;; format 1
-                    "owncloud+https://user1:pass1@myhost.com"
+(setq elfeed-feeds '(
+                     ;; format 1
+                     "owncloud+https://user1:pass1@myhost.com"
 
-                    ;; format 2, for password with special characters
-                    (list "owncloud+https://user2@myhost.com"
-                          :password "password/with|special@characters:")
+                     ;; format 2, for password with special characters
+                     ("owncloud+https://user2@myhost.com"
+                      :password "password/with|special@characters:")
 
-                    ;; format 3, for password in file
-                    (list "owncloud+https://user3@myhost.com"
-                          :password-file "~/.password")
+                     ;; format 3, for password in file
+                     ("owncloud+https://user3@myhost.com"
+                      :password-file "~/.password")
 
-                    ;; format 4, for password in .authinfo, ensure (auth-source-search :host "myhost.com" :port "443" :user "user4") exists
-                    (list "owncloud+https://user4@myhost.com"
-                          :use-authinfo t)
+                     ;; format 4, for password in .authinfo, ensure (auth-source-search :host "myhost.com" :port "443" :user "user4") exists
+                     ("owncloud+https://user4@myhost.com"
+                      :use-authinfo t)
 
-                    ;; format 5, for password in gnome-keyring
-                    (list "owncloud+https://user5@myhost.com"
-                          :password-eval (shell-command-to-string "secret-tool lookup attribute value"))
+                     ;; format 5, for password in gnome-keyring
+                     ("owncloud+https://user5@myhost.com"
+                      :password (shell-command-to-string "secret-tool lookup attribute value"))
 
-                    ;; format 5, for password in pass(1), using password-store.el
-                    (list "owncloud+https://user5@myhost.com"
-                          :password-eval (password-store-get "owncloud/app-pass"))
+                     ;; format 5, for password in pass(1), using password-store.el
+                     ("owncloud+https://user5@myhost.com"
+                      :password (password-store-get "owncloud/app-pass"))
 
-                    ;; use autotags
-                    (list "owncloud+https://user6@myhost.com"
-                          :password "password"
-                          :autotags '(("example.com" comic)))))
+                     ;; use autotags
+                     ("owncloud+https://user6@myhost.com"
+                      :password "password"
+                      :autotags '(("example.com" comic)))))
 (elfeed-protocol-enable)
 ```
 

--- a/elfeed-protocol.el
+++ b/elfeed-protocol.el
@@ -39,7 +39,11 @@
 ;;
 ;;                       ;; format 5, for password in gnome-keyring
 ;;                       (list "owncloud+https://user5@myhost.com"
-;;                             :password (shell-command-to-string "secret-tool lookup attribute value"))
+;;                             :password-eval (shell-command-to-string "secret-tool lookup attribute value"))
+;;
+;;                       ;; format 5, for password in pass(1), using password-store.el
+;;                       (list "owncloud+https://user5@myhost.com"
+;;                             :password-eval (password-store-get "owncloud/app-pass"))
 ;;
 ;;                       ;; use autotags
 ;;                       (list "owncloud+https://user6@myhost.com"
@@ -223,6 +227,8 @@ Will try to get password in url, password filed, passowrd file and
      ((url-password urlobj) (url-password urlobj))
      ((elfeed-protocol-meta-data proto-id :password)
       (elfeed-protocol-meta-data proto-id :password))
+     ((elfeed-protocol-meta-data proto-id :password-eval)
+      (eval (elfeed-protocol-meta-data proto-id :password-eval)))
      ((elfeed-protocol-meta-data proto-id :password-file)
       (elfeed-protocol-get-string-from-file
        (elfeed-protocol-meta-data proto-id :password-file)))


### PR DESCRIPTION
The existing `:password` mechanism isn’t well-suited to fetching a
password from an external store.

 - It fetches once, when `elfeed-feeds` is evaluated, which is likely at Emacs
   startup.  Blocking startup to unlock a password store isn’t a good
   experience.
 - The password is stored in cleartext in the value of the variable.
 - Changing the password in the underlying store requires
   re-evaluating the form which set `elfeed-feeds`.  Many users will
   opt to restart their Emacs session to accomplish this, which is
   needlessly disruptive.

The `:password-eval` mechanism addresses these issues.  Evaluation of
the form given to `:password-eval` is deferred until it’s required,
and the cleartext value is not persisted.  It works equally well for
`shell-command-to-string` invocations, `secrets-get-secret`,
`password-store-get`, etc.

I also though about changing the existing `:password` to notice if the
value was evalable (ex. `(or (functionp f) (and (listp
f) (functionp (car f))))`), but settled on having an explicit key to
get the behavior.  I could go that direction if you feel strongly that
it’s better than `:password-eval`.