### PR TITLE
Fix compilation error about `add-to-list' not being able to use a lexical var

### DIFF
--- a/elfeed-protocol-common.el
+++ b/elfeed-protocol-common.el
@@ -259,7 +259,7 @@ PROTO-ID is the target protocol feed id.  KEY could be :pending-read,
 append."
   (let* ((pending-ids (elfeed-protocol-get-pending-ids proto-id key)))
     (dolist (id ids)
-      (add-to-list 'pending-ids id t))
+      (cl-pushnew id 'pending-ids))
     (elfeed-protocol-set-pending-ids proto-id key pending-ids)))
 (defun elfeed-protocol-remove-pending-ids (proto-id key ids)
   "Remove pending read/unread/starred/unstarred ids that to synchronize later.
@@ -330,7 +330,6 @@ ids. SUB-SIZE is the item size to split for each request."
                                  else collect feed)))
     (cl-loop for url in feed-url-list
              unless (elfeed-protocol-type url) collect url)))
-
 
 (provide 'elfeed-protocol-common)
 


### PR DESCRIPTION
This is a potential fix for https://github.com/fasheng/elfeed-protocol/issues/25

I can't test this at the moment since I am on a computer that doesn't have feeds set up that require this library.  This was the recommended fix from the compiler log after loading the version specified in the ticket.

Please test this before merging, otherwise I will test it later today when I am in an environment that I can test this.