### PR TITLE
Ensure numeric id when parsing JSON from ttrss

### DIFF
--- a/elfeed-protocol-ttrss.el
+++ b/elfeed-protocol-ttrss.el
@@ -319,6 +319,7 @@ it with the result entries as argument.  Return parsed entries."
                                           ('feed_title feed-title)
                                           ('guid guid-hash))
                                      headline)
+                                    (id (if (stringp id) (string-to-number id) id))
                                     (guid-hash
                                      ;; use bulit-in guid hash if exists, or just generate one
                                      (if (null guid-hash)


### PR DESCRIPTION
Syncing with TTRSS stopped working for me with error

```Error running timer ‘elfeed-curl--call-callback’: (wrong-type-argument number-or-marker-p "2141")```

Apparently the JSON returned by TTRSS contains a string representation of a number, instead of a numeric representation. This PR adds the appropriate string-to-number conversion.