### PR TITLE
Fixes for meta-feed and autotagging advice

### DIFF
--- a/elfeed-protocol-common.el
+++ b/elfeed-protocol-common.el
@@ -115,7 +115,7 @@ Which just concat PROTO-ID and FEED-URL, for example
                           (list (when (stringp (car feed)) (car feed)))
                           (string feed)))
              (feed-proto-id (elfeed-protocol-no-password-url feed-url)))
-        (when (string-match (concat "^" (regexp-quote feed-proto-id)) proto-id)
+        (when (string-match (concat "^" proto-id) feed-proto-id)
           (throw 'found feed))))))
 
 (defun elfeed-protocol-meta-url (proto-id)

--- a/elfeed-protocol.el
+++ b/elfeed-protocol.el
@@ -166,7 +166,7 @@ ORIG-FUNC and URL-OR-FEED are the needed arguments."
                       (elfeed-feed-id url-or-feed))
                 url-or-feed))
          (proto-autotags (when (elfeed-protocol-subfeed-p url)
-                           (let* ((proto-id (elfeed-protocol-host-url url))
+                           (let* ((proto-id (elfeed-protocol-type url))
                                   (subfeed-url (elfeed-protocol-subfeed-url url)))
                              (elfeed-protocol-feed-autotags proto-id subfeed-url)))))
     (if proto-autotags


### PR DESCRIPTION
These changes fix points 1 & 2 in #41. The fix elfeed-protocol-meta-feed fixes a more general issue, which would prevent the function from ever extracting the feed object from elfeed-feeds. 